### PR TITLE
Revise deploy script to remove content

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -6,18 +6,18 @@ git checkout --orphan "${buildid}"
 
 hugo -b 'http://blog.synapsegarden.net'
 rm config.toml README.md .gitignore LICENSE
-rm -rf content layouts themes static
+rm -rf content layouts themes static .gitmodules
 mv public/* ./
-echo "*.sw[nop]" > .gitignore
-echo ".gitmodules" >> .gitignore
-echo "blog.synapsegarden.net" > CNAME
 rm -rf public
+echo "*.sw[nop]" > .gitignore
+echo "blog.synapsegarden.net" > CNAME
 rm deploy.sh
 
 git add . --all
 
 git commit -m "Build ${buildid}"
 git checkout gh-pages
-git merge --strategy-option theirs "${buildid}" --squash
+rm -rf *
+git checkout "${buildid}" -- . # Checkout everything
+git add . --all
 git branch -D "${buildid}"
-


### PR DESCRIPTION
Old deploy script was retaining old content from `gh-pages` which had been removed in the newly generated site.

Now, we first remove all content in `gh-pages` before checking out all content from the new build branch.
